### PR TITLE
fix: security settings of favonia/cloudflare-ddns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,9 +129,8 @@ services:
     container_name: cloudflare-ddns
     restart: ${RESTART}
     network_mode: host
+    user: "${PUID}:${PGID}"
     environment:
-      - PGID=${PGID}
-      - PUID=${PUID}
       - CF_API_TOKEN=${CF_API_TOKEN}
       - DOMAINS=${FQDN}
       - PROXIED=false


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16) (released on 16 July), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer, cleaner, and more reliable; but it requires an update to the configuration. In particular, the environment variables `PUID=uid` and `PGID=gid` should be replaced by `user: "uid:gid"` or `--user uid:gid`. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in the updater.

_PS:_ I also recommend adding `cap_drop: [all]` and Docker's other protections. See [README](https://github.com/favonia/cloudflare-ddns/blob/main/README.markdown).